### PR TITLE
optional timeout windows only c/c++ only

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ fullStat returns json data about your server.
         res.send(data);
     });
 ```
+<h5>1)options : (windows only c/c++ only)</h5>
+timeout: number of milliseconds to wait before killing the compiled program
+```javascript
+    //compile and execute the file and kill it after 1 second if it still running
+    var envData = { OS : "linux" , cmd : "gcc" ,options: {timeout:1000 } };
+    compiler.compileCPP(envData , code , function (data) {
+        res.send(data);
+        //data.error = error message 
+        //data.output = output value
+    });
+```
 
 Examples
 ========


### PR DESCRIPTION
optional parameter "options.timeout" was added to envdata

"options.timeout" number of milliseconds to wait before killing the compiled programs

only work on windows

linux support : equivalent of taskkill /im "+filename+".exe /f > nul" in linux will be add later
others languages support will be added later